### PR TITLE
Fix: PouchDB.prototype may have already been defined

### DIFF
--- a/packages/node_modules/pouchdb-replication/src/index.js
+++ b/packages/node_modules/pouchdb-replication/src/index.js
@@ -5,22 +5,24 @@ function replication(PouchDB) {
   PouchDB.replicate = replicate;
   PouchDB.sync = sync;
 
-  Object.defineProperty(PouchDB.prototype, 'replicate', {
-    get: function () {
-      var self = this;
-      if (typeof this.replicateMethods === 'undefined') {
-        this.replicateMethods = {
-          from: function (other, opts, callback) {
-            return self.constructor.replicate(other, self, opts, callback);
-          },
-          to: function (other, opts, callback) {
-            return self.constructor.replicate(self, other, opts, callback);
-          }
-        };
+  if (!PouchDB.prototype.hasOwnProperty('replicate')) {
+    Object.defineProperty(PouchDB.prototype, 'replicate', {
+      get: function () {
+        var self = this;
+        if (typeof this.replicateMethods === 'undefined') {
+          this.replicateMethods = {
+            from: function (other, opts, callback) {
+              return self.constructor.replicate(other, self, opts, callback);
+            },
+            to: function (other, opts, callback) {
+              return self.constructor.replicate(self, other, opts, callback);
+            }
+          };
+        }
+        return this.replicateMethods;
       }
-      return this.replicateMethods;
-    }
-  });
+    });
+  }
 
   PouchDB.prototype.sync = function (dbName, opts, callback) {
     return this.constructor.sync(this, dbName, opts, callback);


### PR DESCRIPTION
I have a use case where I need to include the `PouchDB` library twice in the one package.

On the second `import` statement `PouchDB.prototype.replicate` already exists so throws an Exception.

This fix ensures `PouchDB.prototype.replicate` is only set if it doesn't already exist.